### PR TITLE
Adding quotes around command line argument values

### DIFF
--- a/src/EventStoreWinServiceWrapper/ProcessMapper.cs
+++ b/src/EventStoreWinServiceWrapper/ProcessMapper.cs
@@ -34,7 +34,7 @@ namespace EventStoreWinServiceWrapper
             configParameters.Add("int-ip", internalIp);
 
             return configParameters.Aggregate("",
-                (acc, next) => string.Format("{0} --{1} {2}", acc, next.Key, next.Value));
+                (acc, next) => string.Format("{0} --{1} \"{2}\"", acc, next.Key, next.Value));
         }
 
         private string GetIp(string externalIp)


### PR DESCRIPTION
The service was silently failing if the dbPath or logPath contained spaces, so I added code to put quotes around all argument values generated by the ProcessMapper.