### PR TITLE
Support the EventStore >= v3.1 http-prefix options

### DIFF
--- a/src/EventStoreWinServiceWrapper/ProcessMapper.cs
+++ b/src/EventStoreWinServiceWrapper/ProcessMapper.cs
@@ -24,10 +24,17 @@ namespace EventStoreWinServiceWrapper
             configParameters.Add("log", instance.LogPath);
             configParameters.Add("db", instance.DbPath);
             configParameters.Add("run-projections", instance.RunProjections);
-            if (!string.IsNullOrWhiteSpace(instance.Addresses))
+
+            if (!string.IsNullOrWhiteSpace(instance.InternalAddresses))
             {
-                configParameters.Add("httpprefixes", instance.Addresses);
+                configParameters.Add("int-http-prefixes", instance.InternalAddresses);
             }
+
+            if (!string.IsNullOrWhiteSpace(instance.ExternalAddresses))
+            {
+                configParameters.Add("ext-http-prefixes", instance.ExternalAddresses);
+            }
+
             var externalIp = GetIp(instance.ExternalIP);
             configParameters.Add("ext-ip", externalIp);
             var internalIp = GetIp(instance.InternalIP);

--- a/src/EventStoreWinServiceWrapper/ServiceInstance.cs
+++ b/src/EventStoreWinServiceWrapper/ServiceInstance.cs
@@ -39,11 +39,18 @@ namespace EventStoreWinServiceWrapper
             set { this["logPath"] = value; }
         }
 
-        [ConfigurationProperty("addresses", IsRequired = false)]
-        public string Addresses
+        [ConfigurationProperty("internaladdresses", IsRequired = false)]
+        public string InternalAddresses
         {
-            get { return (string)this["addresses"]; }
-            set { this["addresses"] = value; }
+            get { return (string)this["internaladdresses"]; }
+            set { this["internaladdresses"] = value; }
+        }
+
+        [ConfigurationProperty("externaladdresses", IsRequired = false)]
+        public string ExternalAddresses
+        {
+            get { return (string)this["externaladdresses"]; }
+            set { this["externaladdresses"] = value; }
         }
 
         [ConfigurationProperty("runProjections", IsRequired = false)]


### PR DESCRIPTION
Updates ProcessMapper and ServiceInstance to set the --int-http-prefixes and --ext-http-prefixes options, instead of the old httpprefixes option, which is not supported for versions >= 3.1.
